### PR TITLE
Correct spelling of Volkswagen

### DIFF
--- a/vehicles/volkswagen.json
+++ b/vehicles/volkswagen.json
@@ -7,7 +7,7 @@
       "\\be golf\\b",
       "\\be-golf\\b"
       ],
-      "title": "Volkswagon e-Golf (24kwh)",
+      "title": "Volkswagen e-Golf (24kwh)",
       "type": "BEV",
       "ev_range": 83,
       "battery_size": 24.2, 
@@ -24,7 +24,7 @@
       "\\be golf\\b",
       "\\be-golf\\b"
       ],
-      "title": "Volkswagon e-Golf (36kwh)",
+      "title": "Volkswagen e-Golf (36kwh)",
       "type": "BEV",
       "ev_range": 125,
       "battery_size": 35.8, 


### PR DESCRIPTION
just a minor thing...in Germany they say volks-var-gun :)